### PR TITLE
Don’t HTML-escape Zendesk ticket content

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -116,7 +116,7 @@ class SubmitFeedbackTestCase(SimpleTestCase):
     def test_ticket_success_with_contact_email(self, mock_requests):
         form_data = {
             'referer': '/other/page',
-            'ticket_content': 'Here is some feedback.',
+            'ticket_content': 'Here is some feedback.\n  <script>alert("hello ");</script>  \n',
             'contact_email': 'example@example.com',
         }
 
@@ -126,7 +126,7 @@ class SubmitFeedbackTestCase(SimpleTestCase):
             {'ticket': {'subject': 'Test Feedback with email address',
                         'tags': ['feedback', 'test', 'with-email'],
                         'group_id': 222222,
-                        'comment': {'body': 'Here is some feedback.'},
+                        'comment': {'body': 'Here is some feedback.\n  <script>alert("hello ");</script>'},
                         'requester': {'name': 'Sender: example',
                                       'email': 'example@example.com'},
                         'custom_fields': [{'id': 32, 'value': 'Anonymous'},

--- a/zendesk_tickets/forms.py
+++ b/zendesk_tickets/forms.py
@@ -26,7 +26,7 @@ class BaseTicketForm(forms.Form):
     def submit_ticket(self, request, subject, tags, ticket_template_name,
                       requester_email=None, extra_context={}):
         context = Context(dict(self.cleaned_data, **extra_context))
-        body = loader.get_template(ticket_template_name).render(context)
+        body = loader.get_template(ticket_template_name).render(context).strip()
 
         client.create_ticket(
             subject,

--- a/zendesk_tickets/templates/zendesk_tickets/ticket.txt
+++ b/zendesk_tickets/templates/zendesk_tickets/ticket.txt
@@ -1,1 +1,1 @@
-{{ ticket_content }}
+{{ ticket_content|safe }}


### PR DESCRIPTION
… they’re submitted as plain text encoded as JSON and it’s up to Zendesk to escape for presentation as necessary