### PR TITLE
0.19: Support for Django 5.2 and Python 3.13.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
           - { "django-version": "5.1", "python-version": "3.10" }
           - { "django-version": "5.1", "python-version": "3.11" }
           - { "django-version": "5.1", "python-version": "3.12" }
+          - { "django-version": "5.2", "python-version": "3.10" }
+          - { "django-version": "5.2", "python-version": "3.11" }
+          - { "django-version": "5.2", "python-version": "3.12" }
+          - { "django-version": "5.2", "python-version": "3.13" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,9 @@ Updating and compiling translation files requires the gettext system package to 
 History
 -------
 
+0.19
+    Add experimental support for Django 5.2 & Python 3.13.
+
 0.18
     Add experimental support for Django versions 5.0 & 5.1.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Framework :: Django :: 5.1
+    Framework :: Django :: 5.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
@@ -34,6 +35,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 ; NB: looser python version requirement than what's tested
@@ -45,7 +47,7 @@ packages =
     zendesk_tickets.templates.zendesk_tickets
 include_package_data = true
 install_requires =
-    Django>=2.2,<5.2
+    Django>=2.2,<5.3
     requests
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     {py38,py39,py310,py311,py312}-django42
     {py310,py311,py312}-django50
     {py310,py311,py312}-django51
+    {py310,py311,py312,py313}-django52
     lint
 
 [testenv]
@@ -24,6 +25,7 @@ deps =
     django42: django~=4.2.0
     django50: django~=5.0.0
     django51: django~=5.1.0
+    django52: django~=5.2.0
 commands =
     python scripts/messages.py compile
     python -m tests

--- a/zendesk_tickets/__init__.py
+++ b/zendesk_tickets/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 18)
+VERSION = (0, 19)
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
[Django 5.2](https://docs.djangoproject.com/en/5.2/releases/5.2/) supports Python 3.10, 3.11, 3.12, and 3.13